### PR TITLE
Dpm 112 eventname

### DIFF
--- a/configs/abi/event.abi
+++ b/configs/abi/event.abi
@@ -3,7 +3,7 @@
     "types": [],
     "structs": [
         {
-            "name": "event",
+            "name": "event_data",
             "base": "",
             "fields": [
                 {

--- a/pkg/apps/monitor/config.go
+++ b/pkg/apps/monitor/config.go
@@ -58,7 +58,7 @@ type SessionConfig struct {
 	pingPeriod time.Duration
 
 	maxMessageSize     int64
-	maxEventsInMessage int64
+	maxEventsInMessage int
 }
 
 type UpgraderConfig struct {

--- a/pkg/apps/monitor/decoder.go
+++ b/pkg/apps/monitor/decoder.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	defaultContractActionName = "send"
-	defaultEventStructName    = "event"
+	defaultEventStructName    = "event_data"
 )
 
 type Decoder struct {

--- a/pkg/apps/monitor/monitor.go
+++ b/pkg/apps/monitor/monitor.go
@@ -3,10 +3,10 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"github.com/DaoCasino/platform-action-monitor/pkg/apps/monitor/metrics"
 	"github.com/gorilla/mux"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"net/http"
-	"github.com/DaoCasino/platform-action-monitor/pkg/apps/monitor/metrics"
 )
 
 // Globals
@@ -18,7 +18,7 @@ var (
 	sessionManager *SessionManager
 )
 
-func Init(configFile *string, parentContext context.Context) (*http.Server, func(),  error) {
+func Init(configFile *string, parentContext context.Context) (*http.Server, func(), error) {
 	logger := newLogger(false)
 	EnableDebugLogging(logger)
 
@@ -56,36 +56,8 @@ func Init(configFile *string, parentContext context.Context) (*http.Server, func
 		Handler: router,
 	}
 
-	//done := make(chan os.Signal, 1)
-	//signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-
 	go sessionManager.run(parentContext)
 	go scraper.run(parentContext)
-
-	//go func() {
-	//	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-	//		mainLog.Fatal("listen", zap.Error(err))
-	//	}
-	//}()
-
-	//mainLog.Info("server is listening", zap.String("addr", config.serverAddress))
-
-	//<-done
-	//mainLog.Debug("done signal")
-	//mainCancel()
-
-	//shutdownContextWithTimeout, cancelWaitShutdown := context.WithTimeout(parentContext, withTimeout)
-	//defer func() {
-	//	// TODO: close all connections here
-	//	pool.Close()
-	//
-	//	cancelWaitShutdown()
-	//	mainLog.Debug("connection closed")
-	//}()
-
-	//if err := srv.Shutdown(shutdownContextWithTimeout); err != nil {
-	//	mainLog.Fatal("server shutdown failed", zap.Error(err))
-	//}
 
 	closeFunc := func() {
 		pool.Close()

--- a/pkg/apps/monitor/scraper_test.go
+++ b/pkg/apps/monitor/scraper_test.go
@@ -71,21 +71,3 @@ func TestScraperUnsubscribe(t *testing.T) {
 func TestBroadcastMessage(t *testing.T) {
 	t.Skip("need mock websocket connection")
 }
-
-func TestGetOffsetMessage(t *testing.T) {
-	s := newScraper()
-	s.offset = 666
-
-	parentContext, cancel := context.WithCancel(context.Background())
-	go s.run(parentContext)
-
-	msg := &ScraperGetOffsetMessage{
-		response: make(chan *ScraperResponseMessage),
-	}
-	s.getOffset <- msg
-
-	res := <-msg.response
-	assert.Equal(t, s.offset, res.result)
-
-	cancel()
-}

--- a/pkg/apps/monitor/session.go
+++ b/pkg/apps/monitor/session.go
@@ -346,7 +346,7 @@ func (s *Session) sendQueueMessages(parentContext context.Context) {
 		return
 	}
 
-	chunkSize := int(config.session.maxEventsInMessage) // TODO: <-
+	chunkSize := config.session.maxEventsInMessage
 
 	for i := 0; i < len(events); i += chunkSize {
 		end := i + chunkSize

--- a/pkg/apps/monitor/sessionManager.go
+++ b/pkg/apps/monitor/sessionManager.go
@@ -33,7 +33,7 @@ func newSessionManager() *SessionManager {
 func (s *SessionManager) run(parentContext context.Context) {
 	defer func() {
 		for session := range s.sessions {
-			scraper.unsubscribeSession <- session
+			session.scraper.unsubscribeSession <- session
 
 			delete(s.sessions, session)
 			close(session.queue)


### PR DESCRIPTION
sendMessages вызывалась из readPump и юзала канал s.send  который закрывается в queuePump, поэтому в  sendMessages теперь заполняет очередь отправки потом шлет ее и открывает, а очередь теперь сама режет сообещения на чанки и ей не надо знать сколько там евентов в базе она знает сколько евентов в очереди - поэтому отпал лишний не нужный запрос max