### PR TITLE
feat: set max message size 0, add event in message in config

### DIFF
--- a/configs/config.dev.yml
+++ b/configs/config.dev.yml
@@ -8,7 +8,6 @@ server:
 session:
   writeWait: 10s
   pongWait: 60s
-  maxMessageSize: 0
   maxEventsInMessage: 50
 upgrader:
   readBufferSize: 1024

--- a/configs/config.dev.yml
+++ b/configs/config.dev.yml
@@ -14,8 +14,8 @@ upgrader:
   readBufferSize: 1024
   writeBufferSize: 1024
 abi:
-  main: /app/abi/contract.abi
+  main: configs/abi/contract.abi
   events:
-    0: /app/abi/event.abi
-    1: /app/abi/event.abi
-eventExpires: 1 hour
+    0: configs/abi/event.abi
+    1: configs/abi/event.abi
+eventExpires: 3 hour

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -8,7 +8,6 @@ server:
 session:
   writeWait: 10s
   pongWait: 60s
-  maxMessageSize: 0
   maxEventsInMessage: 50
 upgrader:
   readBufferSize: 1024

--- a/pkg/apps/monitor/config.go
+++ b/pkg/apps/monitor/config.go
@@ -22,7 +22,7 @@ const (
 	defaultPingPeriod = (defaultPongWait * 9) / 10
 
 	// Maximum message size allowed from client.
-	defaultMaxMessageSize = 1024 * 10
+	defaultMaxMessageSize = 0
 
 	// Maximum events to send per message
 	defaultMaxEventsInMessage = 50
@@ -104,9 +104,10 @@ type ConfigFile struct {
 	} `yaml:"server"`
 
 	Session struct {
-		WriteWait      string `yaml:"writeWait"`
-		PongWait       string `yaml:"pongWait"`
-		MaxMessageSize int64  `yaml:"maxMessageSize"`
+		WriteWait          string `yaml:"writeWait"`
+		PongWait           string `yaml:"pongWait"`
+		MaxMessageSize     int64  `yaml:"maxMessageSize"`
+		MaxEventsInMessage int    `yaml:"maxEventsInMessage"`
 	} `yaml:"session"`
 
 	Upgrader struct {
@@ -148,6 +149,7 @@ func (c *Config) assign(target *ConfigFile) (err error) {
 	}
 	c.session.pingPeriod = (c.session.pongWait * 9) / 10
 	c.session.maxMessageSize = target.Session.MaxMessageSize
+	c.session.maxEventsInMessage = target.Session.MaxEventsInMessage
 
 	c.db.url = target.Database.Url
 

--- a/pkg/apps/monitor/config.go
+++ b/pkg/apps/monitor/config.go
@@ -106,7 +106,6 @@ type ConfigFile struct {
 	Session struct {
 		WriteWait          string `yaml:"writeWait"`
 		PongWait           string `yaml:"pongWait"`
-		MaxMessageSize     int64  `yaml:"maxMessageSize"`
 		MaxEventsInMessage int    `yaml:"maxEventsInMessage"`
 	} `yaml:"session"`
 
@@ -148,7 +147,6 @@ func (c *Config) assign(target *ConfigFile) (err error) {
 		return
 	}
 	c.session.pingPeriod = (c.session.pongWait * 9) / 10
-	c.session.maxMessageSize = target.Session.MaxMessageSize
 	c.session.maxEventsInMessage = target.Session.MaxEventsInMessage
 
 	c.db.url = target.Database.Url

--- a/pkg/apps/monitor/config.go
+++ b/pkg/apps/monitor/config.go
@@ -21,8 +21,10 @@ const (
 	// Send pings to client with this period. Must be less than pongWait.
 	defaultPingPeriod = (defaultPongWait * 9) / 10
 
-	// Maximum message size allowed from client.
-	defaultMaxMessageSize = 0
+	// The maximum size in bytes for a message read from the peer. If a
+	// message exceeds the limit, the connection sends a close message to the peer
+	// and returns ErrReadLimit to the application.
+	defaultMessageSizeLimit = 0
 
 	// Maximum events to send per message
 	defaultMaxEventsInMessage = 50
@@ -57,7 +59,7 @@ type SessionConfig struct {
 	pongWait   time.Duration
 	pingPeriod time.Duration
 
-	maxMessageSize     int64
+	messageSizeLimit   int64
 	maxEventsInMessage int
 }
 
@@ -126,7 +128,7 @@ func newDefaultConfig() *Config {
 	config := &Config{
 		db:            DatabaseConfig{defaultDatabaseUrl, DatabaseFilters{nil, nil}},
 		serverAddress: defaultAddr,
-		session:       SessionConfig{defaultWriteWait, defaultPongWait, defaultPingPeriod, defaultMaxMessageSize, defaultMaxEventsInMessage},
+		session:       SessionConfig{defaultWriteWait, defaultPongWait, defaultPingPeriod, defaultMessageSizeLimit, defaultMaxEventsInMessage},
 		upgrader:      UpgraderConfig{defaultReadBufferSize, defaultWriteBufferSize},
 		abi:           AbiConfig{main: defaultContractABI, events: make(map[int]string)},
 		eventExpires:  defaultEventExpires,

--- a/pkg/apps/monitor/config_test.go
+++ b/pkg/apps/monitor/config_test.go
@@ -19,7 +19,6 @@ server:
 session:
   writeWait: 100s
   pongWait: 600s
-  maxMessageSize: 2048
   maxEventsInMessage: 75
 upgrader:
   readBufferSize: 1024
@@ -45,7 +44,6 @@ func TestConfigFile(t *testing.T) {
 
 	assert.Equal(t, "100s", configFile.Session.WriteWait)
 	assert.Equal(t, "600s", configFile.Session.PongWait)
-	assert.Equal(t, int64(2048), configFile.Session.MaxMessageSize)
 	assert.Equal(t, 75, configFile.Session.MaxEventsInMessage)
 
 	assert.Equal(t, 1024, configFile.Upgrader.ReadBufferSize)
@@ -76,7 +74,6 @@ func TestConfigAssign(t *testing.T) {
 
 	assert.Equal(t, 100*time.Second, config.session.writeWait)
 	assert.Equal(t, 600*time.Second, config.session.pongWait)
-	assert.Equal(t, int64(2048), config.session.maxMessageSize)
 	assert.Equal(t, 75, config.session.maxEventsInMessage)
 
 	assert.Equal(t, 1024, config.upgrader.readBufferSize)

--- a/pkg/apps/monitor/config_test.go
+++ b/pkg/apps/monitor/config_test.go
@@ -20,6 +20,7 @@ session:
   writeWait: 100s
   pongWait: 600s
   maxMessageSize: 2048
+  maxEventsInMessage: 75
 upgrader:
   readBufferSize: 1024
   writeBufferSize: 512
@@ -45,6 +46,7 @@ func TestConfigFile(t *testing.T) {
 	assert.Equal(t, "100s", configFile.Session.WriteWait)
 	assert.Equal(t, "600s", configFile.Session.PongWait)
 	assert.Equal(t, int64(2048), configFile.Session.MaxMessageSize)
+	assert.Equal(t, 75, configFile.Session.MaxEventsInMessage)
 
 	assert.Equal(t, 1024, configFile.Upgrader.ReadBufferSize)
 	assert.Equal(t, 512, configFile.Upgrader.WriteBufferSize)
@@ -75,6 +77,7 @@ func TestConfigAssign(t *testing.T) {
 	assert.Equal(t, 100*time.Second, config.session.writeWait)
 	assert.Equal(t, 600*time.Second, config.session.pongWait)
 	assert.Equal(t, int64(2048), config.session.maxMessageSize)
+	assert.Equal(t, 75, config.session.maxEventsInMessage)
 
 	assert.Equal(t, 1024, config.upgrader.readBufferSize)
 	assert.Equal(t, 512, config.upgrader.writeBufferSize)

--- a/pkg/apps/monitor/session.go
+++ b/pkg/apps/monitor/session.go
@@ -50,6 +50,7 @@ type Session struct {
 	// Buffered channel of outbound messages.
 	send          chan []byte
 	queue         chan *Event
+	sendQueue     chan struct{}
 	queueMessages *Queue
 }
 
@@ -63,6 +64,7 @@ func newSession(scraper *Scraper, conn *websocket.Conn) *Session {
 		conn:          conn,
 		send:          make(chan []byte, 512),
 		queue:         make(chan *Event, 32),
+		sendQueue:     make(chan struct{}),
 		queueMessages: newQueue(),
 	}
 }
@@ -131,6 +133,8 @@ func (s *Session) queuePump(parentContext context.Context) {
 		case <-parentContext.Done():
 			sessionLog.Debug("queuePump parent context close")
 			return
+		case <-s.sendQueue:
+			s.sendQueueMessages(queuePumpContext)
 		case event, ok := <-s.queue:
 			if !ok {
 				return
@@ -308,8 +312,15 @@ func (s *Session) sendMessages(parentContext context.Context, topic string, offs
 
 	defer func() {
 		conn.Release()
-		s.sendQueueMessages(parentContext)
-		s.queueMessages.open() // TODO: <- check done?
+
+		select {
+		case <-parentContext.Done():
+			sessionLog.Debug("sendMessage parent context done")
+		case s.sendQueue <- struct{}{}:
+			s.queueMessages.open()
+		case <-time.After(time.Second):
+			sessionLog.Debug("sendQueue timeout")
+		}
 	}()
 
 	events, err := fetchAllEvents(parentContext, conn.Conn(), offset, 0)

--- a/pkg/apps/monitor/session.go
+++ b/pkg/apps/monitor/session.go
@@ -85,7 +85,7 @@ func (s *Session) readPump(parentContext context.Context) {
 
 	sessionLog.Debug("readPump start", zap.String("session.id", s.ID))
 
-	s.conn.SetReadLimit(config.session.maxMessageSize)
+	s.conn.SetReadLimit(config.session.messageSizeLimit)
 	if err := s.conn.SetReadDeadline(time.Now().Add(config.session.pongWait)); err != nil {
 		return
 	}


### PR DESCRIPTION
Посмотрел код библиотеки readLimit не влияет ни на какие буферы, просто
`If a message exceeds the limit, the connection sends a close message to the peer and returns ErrReadLimit to the application.`
```
if c.readLimit > 0 && c.readLength > c.readLimit {
			c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), time.Now().Add(writeWait))
			return noFrame, ErrReadLimit
		}
```
